### PR TITLE
Update control.cc to fix compile error

### DIFF
--- a/mcsmus/mcsmus/control.cc
+++ b/mcsmus/mcsmus/control.cc
@@ -28,6 +28,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <cstdlib>
 #include <cmath>
 #include <signal.h>
+#include <cstdio>
 
 namespace {
     std::function<void()> set_interrupt_function;


### PR DESCRIPTION
The `printf` from the C standard library wasn't properly included which resulted in a compilation error on my system. Adding the missing include fixed the problem.